### PR TITLE
Include missing files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include VERSION


### PR DESCRIPTION
Include missing files in sdist for #13

Tested with

```
++ mktemp -d
+ D=/tmp/tmp.e5uC2y3ofk
+ trap 'rm -rf /tmp/tmp.e5uC2y3ofk' EXIT
+ python -m venv /tmp/tmp.e5uC2y3ofk
+ python setup.py sdist -d /tmp/tmp.e5uC2y3ofk
running sdist
running egg_info
writing splitp.egg-info/PKG-INFO
writing dependency_links to splitp.egg-info/dependency_links.txt
writing top-level names to splitp.egg-info/top_level.txt
reading manifest file 'splitp.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'splitp.egg-info/SOURCES.txt'
running check
creating splitp-0.1.1
creating splitp-0.1.1/splitp
creating splitp-0.1.1/splitp.egg-info
copying files to splitp-0.1.1...
copying MANIFEST.in -> splitp-0.1.1
copying README.md -> splitp-0.1.1
copying VERSION -> splitp-0.1.1
copying setup.py -> splitp-0.1.1
copying splitp/__init__.py -> splitp-0.1.1/splitp
copying splitp/nx_tree.py -> splitp-0.1.1/splitp
copying splitp/parsers.py -> splitp-0.1.1/splitp
copying splitp/tree_helper_functions.py -> splitp-0.1.1/splitp
copying splitp.egg-info/PKG-INFO -> splitp-0.1.1/splitp.egg-info
copying splitp.egg-info/SOURCES.txt -> splitp-0.1.1/splitp.egg-info
copying splitp.egg-info/dependency_links.txt -> splitp-0.1.1/splitp.egg-info
copying splitp.egg-info/top_level.txt -> splitp-0.1.1/splitp.egg-info
Writing splitp-0.1.1/setup.cfg
Creating tar archive
removing 'splitp-0.1.1' (and everything under it)
+ cd /
+ /tmp/tmp.e5uC2y3ofk/bin/pip install /tmp/tmp.e5uC2y3ofk/splitp-0.1.1.tar.gz
Processing /tmp/tmp.e5uC2y3ofk/splitp-0.1.1.tar.gz
Installing collected packages: splitp
  Running setup.py install for splitp: started
    Running setup.py install for splitp: finished with status 'done'
Successfully installed splitp-0.1.1
WARNING: You are using pip version 19.2.3, however version 20.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
+ echo Success
Success
++ rm -rf /tmp/tmp.e5uC2y3ofk
```
